### PR TITLE
Fix keyword argument in multiprocessing example.

### DIFF
--- a/examples/advanced/parallel_evaluation_mp_example.py
+++ b/examples/advanced/parallel_evaluation_mp_example.py
@@ -28,7 +28,7 @@ def main(prng=None, display=False):
     final_pop = ea.evolve(generator=generate_rastrigin, 
                           evaluator=inspyred.ec.evaluators.parallel_evaluation_mp,
                           mp_evaluator=evaluate_rastrigin, 
-                          mp_num_cpus=8,
+                          mp_nprocs=8,
                           pop_size=8, 
                           bounder=inspyred.ec.Bounder(-5.12, 5.12),
                           maximize=False,


### PR DESCRIPTION
The number of processors to use for concurrent evaluation via
multiprocessing was defined in ecspy with the mp_num_cpus
argument. This got changed to mp_nprocs in inspyred, but the example
wasn't updated to reflect the change.
