### PR TITLE
feat: list all packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     url='https://github.com/aarongarrett/inspyred',
     packages=[
         'inspyred',
+        'inspyred.ec',
+        'inspyred.ec.variators',
+        'inspyred.swarm'
     ],
     package_dir={'inspyred':
                  'inspyred'},


### PR DESCRIPTION
We're now using the [new python packaging guidelines](https://www.python.org/dev/peps/pep-0517/) in Fedora, and there, it looks like all the various packages need to be listed in the metadata for them to be included in the build/install. So adding these here. (One can use `setuptools.find_packages` to automatically populate them too)