### PR TITLE
Modified 'plus' replacement

### DIFF
--- a/inspyred/ec/replacers.py
+++ b/inspyred/ec/replacers.py
@@ -185,7 +185,7 @@ def plus_replacement(random, population, parents, offspring, args):
 
     """
     pool = list(offspring)
-    pool.extend(parents)
+    pool.extend(population)
     pool.sort(reverse=True)
     survivors = pool[:len(population)]
     return survivors


### PR DESCRIPTION
Now the 'plus' replacement merges the offspring with the whole current population, before sorting and truncation. This is more coherent with the expected behavior described in specialized literature.